### PR TITLE
runner.py: avoid two '--extra-settings' in argv

### DIFF
--- a/djangocms_helper/runner.py
+++ b/djangocms_helper/runner.py
@@ -20,7 +20,7 @@ def run(app, argv=sys.argv):
     # This is a hackish to get the caller file which is the file
     # which contains the HELPER_SETTINGS
     helper = os.path.abspath(inspect.getframeinfo(inspect.stack()[1][0]).filename)
-    if os.path.basename(helper) != HELPER_FILE:
+    if os.path.basename(helper) != HELPER_FILE and '--extra-settings=%s' % helper not in argv:
         argv.append('--extra-settings=%s' % helper)
     main()
 
@@ -45,6 +45,6 @@ def cms(app, argv=sys.argv):
     # This is a hackish to get the caller file which is the file
     # which contains the HELPER_SETTINGS
     helper = os.path.abspath(inspect.getframeinfo(inspect.stack()[1][0]).filename)
-    if os.path.basename(helper) != HELPER_FILE:
+    if os.path.basename(helper) != HELPER_FILE and '--extra-settings=%s' % helper not in argv:
         argv.append('--extra-settings=%s' % helper)
     main()


### PR DESCRIPTION
When running `djangocms-helper server` I get following error:

```
  File "/home/felipe/.virtualenvs/blahhh/lib/python2.7/site-packages/django_cms-3.0.9-py2.7.egg/cms/utils/setup.py", line 13, in validate_dependencies
    raise ImproperlyConfigured('django CMS requires django-mptt package.')
django.core.exceptions.ImproperlyConfigured: django CMS requires django-mptt package.
```

Checking I have found that runner is adding twice the '--extra-settings' and fixing it solved my problem.