### PR TITLE
Fix #46: Do not override boilerplate name with defaults.

### DIFF
--- a/djangocms_helper/utils.py
+++ b/djangocms_helper/utils.py
@@ -264,6 +264,10 @@ def _make_settings(args, application, settings, STATIC_ROOT, MEDIA_ROOT):
     if args['--boilerplate']:
         boilerplate_settings = get_boilerplates_settings()
 
+        # Do not override helper settings with defaults.
+        if 'ALDRYN_BOILERPLATE_NAME' in default_settings.keys():
+            del boilerplate_settings['ALDRYN_BOILERPLATE_NAME']
+
         for item in boilerplate_settings['STATICFILES_FINDERS']:
             if item not in default_settings['STATICFILES_FINDERS']:
                 default_settings['STATICFILES_FINDERS'].insert(


### PR DESCRIPTION
If ``ALDRYN_BOILERPLATE_NAME`` is defined somewhere earlier - do not override it with defaults from ``get_boilerplates_settings``