### PR TITLE
Unicode issue: force arguments to be unicode, ensure they are unique.

### DIFF
--- a/djangocms_helper/main.py
+++ b/djangocms_helper/main.py
@@ -331,7 +331,8 @@ def main(argv=sys.argv):  # pragma: no cover
         application = argv[1]
         application_module = import_module(application)
         try:
-            args = docopt(__doc__, argv=argv,
+            # by default docopt uses sys.argv[1:]; ensure correct args passed
+            args = docopt(__doc__, argv=argv[1:],
                           version=application_module.__version__)
             if argv[2] == 'help':
                 raise DocoptExit()

--- a/djangocms_helper/main.py
+++ b/djangocms_helper/main.py
@@ -325,18 +325,13 @@ def main(argv=sys.argv):  # pragma: no cover
     # Command is executed in the main directory of the plugin, and we must
     # include it in the current path for the imports to work
     sys.path.insert(0, '.')
-    # if is different from default ensure that it is prepared properly.
+    # ensure that argv, are unique and the same type as doc string
     argv = ensure_unicoded_and_unique(argv)
     if len(argv) > 1:
         application = argv[1]
         application_module = import_module(application)
         try:
-            # docopt uses sys.argv[1:] by default, but we need to ensure that
-            # all args are unicode strings, otherwise it would miss match
-            # string sys.args with unicode __doc__ descriptions for args.
-            # Also ensuring that arguments are unique
-            unicoded_argv = ensure_unicoded_and_unique(sys.argv[1:])
-            args = docopt(__doc__, argv=unicoded_argv,
+            args = docopt(__doc__, argv=argv,
                           version=application_module.__version__)
             if argv[2] == 'help':
                 raise DocoptExit()

--- a/djangocms_helper/utils.py
+++ b/djangocms_helper/utils.py
@@ -431,3 +431,18 @@ class UserLoginContext(object):
     def __exit__(self, exc, value, tb):
         self.testcase._login_context = None
         self.testcase.client.logout()
+
+
+def ensure_unicoded_and_unique(args_list):
+    """
+    Iterate over args_list, make it unicode if needed and ensure that there
+    are no duplicates.
+    Returns list of unicoded arguments in the same order.
+    """
+    unicoded_args = []
+    for argument in args_list:
+        argument = (unicode(argument)
+                    if type(argument) == str else argument)
+        if argument not in unicoded_args:
+            unicoded_args.append(argument)
+    return unicoded_args

--- a/djangocms_helper/utils.py
+++ b/djangocms_helper/utils.py
@@ -15,6 +15,7 @@ from django.core.management import call_command
 from django.core.urlresolvers import clear_url_caches
 from django.utils.datastructures import SortedDict
 from django.utils.functional import empty
+from django.utils import six
 from django.utils.six import StringIO
 
 try:
@@ -441,8 +442,8 @@ def ensure_unicoded_and_unique(args_list):
     """
     unicoded_args = []
     for argument in args_list:
-        argument = (unicode(argument)
-                    if type(argument) == str else argument)
+        argument = (six.u(argument)
+                    if not isinstance(argument, six.text_type) else argument)
         if argument not in unicoded_args:
             unicoded_args.append(argument)
     return unicoded_args


### PR DESCRIPTION
The issue is related to the fact that django runserver command spwans a new process/thread which gets non unicoded arguments in sys.argv.
Also if some of the arguments was passed twice (or was duplicated because of that spawn) docopt wasn't able to map arguments correctly.

Should fix issue #48