### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Common options
 
 * ``--cms``: Loads configuration to properly run a django CMS-based application;
 * ``--extra-settings``: Path to a helper file to set extra settings; see
-  `Settings section <http://djangocms-helper.readthedocs.org/en/develop/settings.html>`_
+  `Settings section <https://djangocms-helper.readthedocs.io/en/develop/settings.html>`_
   for details;
 
 *****
@@ -90,7 +90,7 @@ Runner
 
 By using the integrated runned in the settings file you'll be able to run
 the commands without invoking ``djangocms-helper``: see
-`Integrate runner <http://djangocms-helper.readthedocs.org/en/develop/runner.html>`_
+`Integrate runner <https://djangocms-helper.readthedocs.io/en/develop/runner.html>`_
 for reference.
 
 ************
@@ -118,7 +118,7 @@ Requirements
 Documentation
 *************
 
-Documentation is available on `readthedocs <http://djangocms-helper.readthedocs.org>`_.
+Documentation is available on `readthedocs <https://djangocms-helper.readthedocs.io>`_.
 
 
 *******


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.