### PR TITLE
Add support for channels runserver

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 ++++++++++++++++++
 
 * Added support for channels runserver.
+* Added verbosity level to server command.
 
 0.9.5 (2016-06-06)
 ++++++++++++++++++

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+0.9.6 (unreleased)
+++++++++++++++++++
+
+* Added support for channels runserver.
+
 0.9.5 (2016-06-06)
 ++++++++++++++++++
 

--- a/djangocms_helper/__init__.py
+++ b/djangocms_helper/__init__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-"""djangocms-helper - Helpers for django CMS plugin development"""
 from __future__ import absolute_import, print_function, unicode_literals
 
-__version__ = '0.9.4.post2'
+__version__ = '0.9.5.post1'
 __author__ = 'Iacopo Spalletti <i.spalletti@nephila.it>'
 __all__ = ['runner']
 

--- a/djangocms_helper/main.py
+++ b/djangocms_helper/main.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import warnings
 
+from django.utils import autoreload
 from django.utils.encoding import force_text
 from django.utils.six import text_type
 from docopt import DocoptExit, docopt
@@ -236,7 +237,7 @@ def static_analisys(application):
 
 
 def server(bind='127.0.0.1', port=8000, migrate_cmd=False, verbose=1):  # pragma: no cover
-    from django.utils import autoreload
+    from django.contrib.staticfiles.management.commands import runserver
 
     if os.environ.get('RUN_MAIN') != 'true':
         _create_db(migrate_cmd)
@@ -248,7 +249,6 @@ def server(bind='127.0.0.1', port=8000, migrate_cmd=False, verbose=1):  # pragma
             print('A admin user (username: %s, password: admin) '
                   'has been created.' % usr.get_username())
             print('')
-    from django.contrib.staticfiles.management.commands import runserver
     rs = runserver.Command()
     try:
         from django.core.management.base import OutputWrapper

--- a/djangocms_helper/main.py
+++ b/djangocms_helper/main.py
@@ -261,10 +261,17 @@ def server(bind='127.0.0.1', port=8000, migrate_cmd=False):  # pragma: no cover
     rs._raw_ipv6 = False
     rs.addr = bind
     rs.port = port
+    try:
+        from channels.log import setup_logger
+        rs.logger = setup_logger('django.channels', 1)
+    except ImportError:
+        pass
     autoreload.main(rs.inner_run, (), {
         'addrport': '%s:%s' % (bind, port),
         'insecure_serving': True,
-        'use_threading': True
+        'use_threading': True,
+        'verbosity': 1,
+        'use_reloader': True,
     })
 
 

--- a/djangocms_helper/main.py
+++ b/djangocms_helper/main.py
@@ -31,7 +31,7 @@ Usage:
     djangocms-helper <application> makemigrations [--extra-settings=</path/to/settings.py>] [--cms] [--merge] [--empty] [--dry-run] [--boilerplate] [<extra-applications>...]
     djangocms-helper <application> pyflakes [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate]
     djangocms-helper <application> authors [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate]
-    djangocms-helper <application> server [--port=<port>] [--bind=<bind>] [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate] [--migrate] [--no-migrate] [--persistent[=path]]
+    djangocms-helper <application> server [--port=<port>] [--bind=<bind>] [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate] [--migrate] [--no-migrate] [--persistent[=path]] [--verbose=<level>]
     djangocms-helper <application> setup [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate]
     djangocms-helper <application> <command> [options] [--extra-settings=</path/to/settings.py>] [--cms] [--boilerplate] [--migrate] [--no-migrate]
 
@@ -235,7 +235,7 @@ def static_analisys(application):
         print('Static analisys available only if django CMS is installed')
 
 
-def server(bind='127.0.0.1', port=8000, migrate_cmd=False):  # pragma: no cover
+def server(bind='127.0.0.1', port=8000, migrate_cmd=False, verbose=1):  # pragma: no cover
     from django.utils import autoreload
 
     if os.environ.get('RUN_MAIN') != 'true':
@@ -270,7 +270,7 @@ def server(bind='127.0.0.1', port=8000, migrate_cmd=False):  # pragma: no cover
         'addrport': '%s:%s' % (bind, port),
         'insecure_serving': True,
         'use_threading': True,
-        'verbosity': 1,
+        'verbosity': verbose,
         'use_reloader': True,
     })
 
@@ -347,7 +347,10 @@ def core(args, application):
                                             args['--runner-options'], args.get('--verbose', 1))
                         sys.exit(num_failures)
                 elif args['server']:
-                    server(args['--bind'], args['--port'], args.get('--migrate', True))
+                    server(
+                        args['--bind'], args['--port'], args.get('--migrate', True),
+                        args.get('--verbose', 1)
+                    )
                 elif args['cms_check']:
                     cms_check(args.get('--migrate', True))
                 elif args['compilemessages']:

--- a/djangocms_helper/tests/test_commands.py
+++ b/djangocms_helper/tests/test_commands.py
@@ -197,7 +197,20 @@ class CommandTests(unittest.TestCase):
                                 elif name == 'TEMPLATE_CONTEXT_PROCESSORS':
                                     self.assertTrue(set(local_settings.TEMPLATES[0]['OPTIONS']['context_processors']).intersection(set(value)))
                                 elif name == 'TEMPLATE_LOADERS':
+
                                     self.assertTrue(set(local_settings.TEMPLATES[0]['OPTIONS']['loaders']).intersection(set(value)))
+
+    @patch('djangocms_helper.main.autoreload')
+    def test_server(self, mocked_command):
+        with work_in(self.basedir):
+            with captured_output() as (out, err):
+                args = copy(DEFAULT_ARGS)
+                args['server'] = True
+                core(args, self.application)
+            self.assertTrue(
+                'A admin user (username: admin, password: admin) has been created.' in
+                out.getvalue()
+            )
 
     def test_makemigrations(self):
         with work_in(self.basedir):


### PR DESCRIPTION
channels requires different arguments / setup. This is valid as of channel 0.15

Fix #74 