### PR TITLE
Minimal changes to allow third party application to run django 2.0 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
   - DJANGO='django110' CMS='cmsno'
   - DJANGO='django111' CMS='cms34'
   - DJANGO='django111' CMS='cmsno'
+  - DJANGO='django20' CMS='cms34'
+  - DJANGO='django20' CMS='cmsno'
 
 before_install:
   - pip install codecov
@@ -55,3 +57,21 @@ matrix:
     env: TOXENV='pep8'
   - python: 3.5
     env: TOXENV='isort'
+
+  allow_failures:
+  - python: 2.7
+    env: DJANGO='django20' CMS='cms34'
+  - python: 2.7
+    env: DJANGO='django20' CMS='cmsno'
+  - python: 3.4
+    env: DJANGO='django20' CMS='cms34'
+  - python: 3.4
+    env: DJANGO='django20' CMS='cmsno'
+  - python: 3.5
+    env: DJANGO='django20' CMS='cms34'
+  - python: 3.5
+    env: DJANGO='django20' CMS='cmsno'
+  - python: 3.6
+    env: DJANGO='django20' CMS='cms34'
+  - python: 3.6
+    env: DJANGO='django20' CMS='cmsno'

--- a/djangocms_helper/base_test.py
+++ b/djangocms_helper/base_test.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import os.path
+from collections import OrderedDict
 from contextlib import contextmanager
 from copy import deepcopy
 from tempfile import mkdtemp
@@ -15,9 +16,7 @@ from django.test import RequestFactory, TestCase
 from django.utils.functional import SimpleLazyObject
 from django.utils.six import StringIO
 
-from .utils import (
-    DJANGO_1_9, OrderedDict, UserLoginContext, create_user, get_user_model, reload_urls, temp_dir,
-)
+from .utils import DJANGO_1_9, UserLoginContext, create_user, get_user_model, reload_urls, temp_dir
 
 try:
     from unittest.mock import patch
@@ -293,7 +292,11 @@ class BaseTestCase(TestCase):
                 user = self._login_context.user
             else:
                 user = AnonymousUser()
-        if user.is_authenticated():
+        if callable(user.is_authenticated):
+            authenticated = user.is_authenticated()
+        else:
+            authenticated = user.is_authenticated
+        if authenticated:
             session_key = user._meta.pk.value_to_string(user)
         else:
             session_key = 'session_key'

--- a/djangocms_helper/test_utils/example1/tests/test_fake.py
+++ b/djangocms_helper/test_utils/example1/tests/test_fake.py
@@ -233,7 +233,8 @@ try:
                 self.assertEqual(request.current_page.get_absolute_url(), pages[1].get_absolute_url())
 
 
-except Exception:
+except Exception as e:
+    print(e)
     from unittest2 import TestCase
 
     class FakeTests(TestCase):

--- a/djangocms_helper/urls.py
+++ b/djangocms_helper/urls.py
@@ -5,10 +5,16 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.i18n import i18n_patterns
 from django.contrib import admin
-from django.views.i18n import javascript_catalog
 from django.views.static import serve
 
-from .utils import DJANGO_1_7, load_from_file
+from .utils import load_from_file
+
+try:
+    from django.views.i18n import JavaScriptCatalog
+    javascript_catalog = JavaScriptCatalog.as_view()
+except ImportError:
+    from django.views.i18n import javascript_catalog
+
 
 admin.autodiscover()
 
@@ -17,10 +23,15 @@ urlpatterns = [
         {'document_root': settings.MEDIA_ROOT, 'show_indexes': True}),
     url(r'^jsi18n/(?P<packages>\S+?)/$', javascript_catalog),  # NOQA
 ]
+try:
+    i18n_urls = [
+        url(r'^admin/', admin.site.urls),
+    ]
+except Exception:
+    i18n_urls = [
+        url(r'^admin/', include(admin.site.urls)),
+    ]
 
-i18n_urls = [
-    url(r'^admin/', include(admin.site.urls)),  # NOQA
-]
 try:
     load_from_file('%s.urls' % settings.BASE_APPLICATION)
     i18n_urls.append(
@@ -34,7 +45,4 @@ if settings.USE_CMS:
         url(r'^', include('cms.urls'))  # NOQA
     )
 
-if not DJANGO_1_7:
-    urlpatterns += i18n_patterns(*i18n_urls)
-else:
-    urlpatterns += i18n_patterns('', *i18n_urls)
+urlpatterns += i18n_patterns(*i18n_urls)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pep8,isort,docs,py{36,35,34,27}-django{111,110,19,18}-cms{34,no}
+envlist = pep8,isort,docs,py{36,35,34,27}-django{20,111,110,19,18}-cms{34,no}
 skip_missing_interpreters=True
 
 [testenv]
@@ -18,6 +18,10 @@ deps=
     django111: django-mptt>0.8
     django111: django-nose<1.5
     django111: easy-thumbnails>2.4
+    django20: django>=2,<2.1
+    django20: django-mptt>0.8
+    django20: django-nose<1.5
+    django20: easy-thumbnails>2.4
     https://github.com/divio/django-filer/archive/develop.zip
     cms34: https://github.com/divio/django-cms/archive/release/3.4.x.zip
     cms34: https://github.com/divio/djangocms-text-ckeditor/archive/master.zip


### PR DESCRIPTION
Django 2.0 tests for `cmsno` configuration requires a Django 2.0 compatible version of filer, which is in the works
In the meantime this PR can be merged to allow other projects to use djangocms-helper to run
The filer os expected to be resolved before the release of version 1.1