### PR TITLE
Fixed issue when generic command require application name

### DIFF
--- a/djangocms_helper/main.py
+++ b/djangocms_helper/main.py
@@ -375,10 +375,10 @@ def main(argv=sys.argv):  # pragma: no cover
     # Command is executed in the main directory of the plugin, and we must
     # include it in the current path for the imports to work
     sys.path.insert(0, '.')
-    # ensure that argv, are unique and the same type as doc string
-    argv = ensure_unicoded_and_unique(argv)
     if len(argv) > 1:
         application = argv[1]
+        # ensure that argv, are unique and the same type as doc string
+        argv = ensure_unicoded_and_unique(argv, application)
         application_module = __import__(application)
         args = _map_argv(argv, application_module)
         return core(args=args, application=application)

--- a/djangocms_helper/utils.py
+++ b/djangocms_helper/utils.py
@@ -411,7 +411,7 @@ class UserLoginContext(object):
         self.testcase.client.logout()
 
 
-def ensure_unicoded_and_unique(args_list):
+def ensure_unicoded_and_unique(args_list, application):
     """
     Iterate over args_list, make it unicode if needed and ensure that there
     are no duplicates.
@@ -421,6 +421,6 @@ def ensure_unicoded_and_unique(args_list):
     for argument in args_list:
         argument = (six.u(argument)
                     if not isinstance(argument, six.text_type) else argument)
-        if argument not in unicoded_args:
+        if argument not in unicoded_args or argument == application:
             unicoded_args.append(argument)
     return unicoded_args


### PR DESCRIPTION
For example `squashmigrations` via generic `<command>` interface