### PR TITLE
Fix regression introduced by #116

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+1.2.4 (unreleased)
+++++++++++++++++++
+
+* Fixed regression introduced by #116
+
 1.2.3 (2019-08-05)
 ++++++++++++++++++
 

--- a/djangocms_helper/base_test.py
+++ b/djangocms_helper/base_test.py
@@ -276,8 +276,7 @@ class BaseTestCaseMixin(object):
 
         engine = import_module(settings.SESSION_ENGINE)
 
-        if page:
-            request.current_page = SimpleLazyObject(lambda: page)
+        request.current_page = SimpleLazyObject(lambda: page)
         if not user:
             if self._login_context:
                 user = self._login_context.user

--- a/djangocms_helper/test_utils/example1/tests/test_fake.py
+++ b/djangocms_helper/test_utils/example1/tests/test_fake.py
@@ -93,6 +93,11 @@ try:
                 self.assertEqual(request.META['REQUEST_METHOD'], 'GET')
                 self.assertEqual(request.current_page, pages[1])
 
+                request = self.get_request(None, 'en', path='/cumstom-path/')
+                self.assertEqual(request.path, '/cumstom-path/')
+                self.assertEqual(request.META['REQUEST_METHOD'], 'GET')
+                self.assertEqual(request.current_page, None)
+
                 request = self.post_request(pages[1], 'en', data={'payload': 1})
                 self.assertEqual(request.path, '/en/second-page/')
                 self.assertEqual(request.META['REQUEST_METHOD'], 'POST')


### PR DESCRIPTION
Let's always add `current_page` to the request, even if the page is `None`, for backward compatibility

We might introduce a different argument to skip this